### PR TITLE
Addition of ECEF coordinate frame for GNSS-message

### DIFF
--- a/uavcan/equipment/gnss/1060.Fix.uavcan
+++ b/uavcan/equipment/gnss/1060.Fix.uavcan
@@ -1,5 +1,6 @@
 #
 # GNSS navigation solution with uncertainty.
+# This message is deprecated. Use the newer 1063.Fix2.uavcan message.
 #
 
 uavcan.Timestamp timestamp         # Global network-synchronized time, if available, otherwise zero

--- a/uavcan/equipment/gnss/1063.Fix2.uavcan
+++ b/uavcan/equipment/gnss/1063.Fix2.uavcan
@@ -1,0 +1,64 @@
+#
+# GNSS ECEF navigation solution with uncertainty.
+#
+
+uavcan.Timestamp timestamp         # Global network-synchronized time, if available, otherwise zero
+
+#
+# Time solution.
+# Time standard (GPS, UTC, TAI, etc) is defined in the field below.
+#
+uavcan.Timestamp gnss_timestamp    # GNSS timestamp, if available, otherwise zero
+
+#
+# Time standard used in the GNSS timestamp field.
+#
+uint3 GNSS_TIME_STANDARD_NONE = 0  # Time is unknown
+uint3 GNSS_TIME_STANDARD_TAI  = 1
+uint3 GNSS_TIME_STANDARD_UTC  = 2
+uint3 GNSS_TIME_STANDARD_GPS  = 3
+uint3 gnss_time_standard
+
+void5   # Reserved space
+
+#
+# If known, the number of leap seconds allows to perform conversions between some time standards.
+#
+uint8 NUM_LEAP_SECONDS_UNKNOWN = 0
+uint8 num_leap_seconds
+
+#
+# Position and velocity solution
+#
+int37 longitude_deg_1e8            # Longitude degrees multiplied by 1e8 (approx. 1 mm per LSB)
+int37 latitude_deg_1e8             # Latitude degrees multiplied by 1e8 (approx. 1 mm per LSB on equator)
+int27 height_ellipsoid_mm          # Height above ellipsoid in millimeters
+int27 height_msl_mm                # Height above mean sea level in millimeters
+
+float16[3] ned_velocity            # NED frame (north-east-down) in meters per second
+
+#
+# Fix status
+#
+uint6 sats_used
+
+uint2 STATUS_NO_FIX    = 0
+uint2 STATUS_TIME_ONLY = 1
+uint2 STATUS_2D_FIX    = 2
+uint2 STATUS_3D_FIX    = 3
+uint2 status
+
+#
+# Precision
+#
+float16 pdop
+
+float16[<=9] position_covariance   # m^2
+float16[<=9] velocity_covariance   # (m/s)^2
+float16[<=9] pos_vel_covariance    # m^2 / s - Covariance 
+
+#
+# Position solution in ECEF
+#
+
+ECEFPosition[<=1] ecef_position

--- a/uavcan/equipment/gnss/1063.Fix2.uavcan
+++ b/uavcan/equipment/gnss/1063.Fix2.uavcan
@@ -19,7 +19,7 @@ uint3 GNSS_TIME_STANDARD_UTC  = 2
 uint3 GNSS_TIME_STANDARD_GPS  = 3
 uint3 gnss_time_standard
 
-void5   # Reserved space
+void13   # Reserved space
 
 #
 # If known, the number of leap seconds allows to perform conversions between some time standards.
@@ -49,7 +49,7 @@ uint2 STATUS_3D_FIX    = 3
 uint2 status
 
 #
-# Mode status
+# GNSS Mode
 # 
 uint3 MODE_SINGLE      = 0
 uint3 MODE_DGPS        = 1
@@ -57,30 +57,27 @@ uint3 MODE_RTK         = 2
 uint3 MODE_PPP         = 3
 uint3 mode
 
-void1   # Reserved space
-
 #
-# Submode status
+# GNSS Sub mode
 #
 
-uint3 SUB_MODE_DGPS_OTHER    = 0
-uint3 SUB_MODE_DGPS_SBAS     = 1
+uint5 SUB_MODE_DGPS_OTHER    = 0
+uint5 SUB_MODE_DGPS_SBAS     = 1
 
-uint3 SUB_MODE_RTK_FLOAT     = 0
-uint3 SUB_MODE_RTK_FIXED     = 1
+uint5 SUB_MODE_RTK_FLOAT     = 0
+uint5 SUB_MODE_RTK_FIXED     = 1
 
-uint3 sub_mode
-
-void1   # Reserved space
+uint5 sub_mode
 
 #
 # Precision
 #
 float16 pdop
 
-float16[<=6] position_covariance   # m^2
-float16[<=6] velocity_covariance   # (m/s)^2
-float16[<=9] pos_vel_covariance    # m^2 / s - Covariance of position and velocity.
+float16[<=21] covariance    # Position and velocity covariance. The upper-right
+                            # triangle of a 6x6 symmetric matrix, represented in
+                            # row-major order. Units are m^2 for position, (m/s)^2
+                            # for velocity and m^2/s for position/velocity.
 
 #
 # Position solution in ECEF

--- a/uavcan/equipment/gnss/1063.Fix2.uavcan
+++ b/uavcan/equipment/gnss/1063.Fix2.uavcan
@@ -55,7 +55,7 @@ float16 pdop
 
 float16[<=9] position_covariance   # m^2
 float16[<=9] velocity_covariance   # (m/s)^2
-float16[<=9] pos_vel_covariance    # m^2 / s - Covariance 
+float16[<=9] pos_vel_covariance    # m^2 / s - Covariance of position and velocity.
 
 #
 # Position solution in ECEF

--- a/uavcan/equipment/gnss/1063.Fix2.uavcan
+++ b/uavcan/equipment/gnss/1063.Fix2.uavcan
@@ -49,6 +49,34 @@ uint2 STATUS_3D_FIX    = 3
 uint2 status
 
 #
+# Mode status
+# 
+uint3 MODE_SINGLE      = 0
+uint3 MODE_DGPS        = 1
+uint3 MODE_RTK         = 2
+uint3 MODE_PPP         = 3
+uint3 mode
+
+void1   # Reserved space
+
+#
+# Submode status
+#
+uint3 SUB_MODE_SINGLE        = 0
+
+uint3 SUB_MODE_DGPS_OTHER    = 0
+uint3 SUB_MODE_DGPS_SBAS     = 1
+
+uint3 SUB_MODE_RTK_FLOAT     = 0
+uint3 SUB_MODE_RTK_FIXED     = 1
+
+uint3 SUB_MODE_PPP           = 0
+
+uint3 sub_mode
+
+void1   # Reserved space
+
+#
 # Precision
 #
 float16 pdop

--- a/uavcan/equipment/gnss/1063.Fix2.uavcan
+++ b/uavcan/equipment/gnss/1063.Fix2.uavcan
@@ -1,5 +1,5 @@
 #
-# GNSS ECEF navigation solution with uncertainty.
+# GNSS ECEF and LLA navigation solution with uncertainty.
 #
 
 uavcan.Timestamp timestamp         # Global network-synchronized time, if available, otherwise zero
@@ -62,15 +62,12 @@ void1   # Reserved space
 #
 # Submode status
 #
-uint3 SUB_MODE_SINGLE        = 0
 
 uint3 SUB_MODE_DGPS_OTHER    = 0
 uint3 SUB_MODE_DGPS_SBAS     = 1
 
 uint3 SUB_MODE_RTK_FLOAT     = 0
 uint3 SUB_MODE_RTK_FIXED     = 1
-
-uint3 SUB_MODE_PPP           = 0
 
 uint3 sub_mode
 
@@ -81,8 +78,8 @@ void1   # Reserved space
 #
 float16 pdop
 
-float16[<=9] position_covariance   # m^2
-float16[<=9] velocity_covariance   # (m/s)^2
+float16[<=6] position_covariance   # m^2
+float16[<=6] velocity_covariance   # (m/s)^2
 float16[<=9] pos_vel_covariance    # m^2 / s - Covariance of position and velocity.
 
 #

--- a/uavcan/equipment/gnss/1063.Fix2.uavcan
+++ b/uavcan/equipment/gnss/1063.Fix2.uavcan
@@ -74,10 +74,9 @@ uint5 sub_mode
 #
 float16 pdop
 
-float16[<=21] covariance    # Position and velocity covariance. The upper-right
-                            # triangle of a 6x6 symmetric matrix, represented in
-                            # row-major order. Units are m^2 for position, (m/s)^2
-                            # for velocity and m^2/s for position/velocity.
+float16[<=36] covariance    # Position and velocity covariance. Units are
+                            # m^2 for position, (m/s)^2 for velocity and
+                            # m^2/s for position/velocity.
 
 #
 # Position solution in ECEF

--- a/uavcan/equipment/gnss/ECEFPosition.uavcan
+++ b/uavcan/equipment/gnss/ECEFPosition.uavcan
@@ -10,8 +10,8 @@
 # pointing from the origin towards the north-pole. The y-axis completes a
 # right-handed coordinate system.
 
-int34 x_mm                         # X-axis coordinate in mm
-int34 y_mm                         # Y-axis coordinate in mm
-int34 z_mm                         # Y-axis coordinate in mm
+int36 x_mm                         # X-axis coordinate in mm
+int36 y_mm                         # Y-axis coordinate in mm
+int36 z_mm                         # Y-axis coordinate in mm
 
-void2                              # Padding to make this field a multiple of 8 bits
+void4                              # Padding to make this field a multiple of 8 bits

--- a/uavcan/equipment/gnss/ECEFPosition.uavcan
+++ b/uavcan/equipment/gnss/ECEFPosition.uavcan
@@ -10,8 +10,6 @@
 # pointing from the origin towards the north-pole. The y-axis completes a
 # right-handed coordinate system.
 
-int36 x_mm                         # X-axis coordinate in mm
-int36 y_mm                         # Y-axis coordinate in mm
-int36 z_mm                         # Y-axis coordinate in mm
+int36[3] xyz_mm                    # XYZ-axis coordinates in mm
 
 void4                              # Padding to make this field a multiple of 8 bits

--- a/uavcan/equipment/gnss/ECEFPosition.uavcan
+++ b/uavcan/equipment/gnss/ECEFPosition.uavcan
@@ -1,0 +1,17 @@
+#
+# Nested type.
+# GNSS ECEF status field.
+#
+# ECEF is an acronym for Earth-Centered-Earth-Fixed, which is a cartesian
+# coordinate system which rotates with the earth. The origin (0,0,0) is
+# located at the center of the earth. The x-axis is a vector pointing from
+# the origin with positive direction towards 0 degrees latitude and
+# longitude (equator, at the prime meridian). The z-axis is a vector
+# pointing from the origin towards the north-pole. The y-axis completes a
+# right-handed coordinate system.
+
+int34 x_mm                         # X-axis coordinate in mm
+int34 y_mm                         # Y-axis coordinate in mm
+int34 z_mm                         # Y-axis coordinate in mm
+
+void2                              # Padding to make this field a multiple of 8 bits


### PR DESCRIPTION
Added draft for a new GNSS-message containing ECEF coordinate representation: 1063.Fix2.uavcan. In addition, a new field for a 3x3 covariance matrix is included: pos_vel_covariance. This describes the covariance between position and velocity. Since covariance matrices are symmetric, only the upper-right quadrant of the 6-by-6 matrix is required.

Fixes #9 