### PR TITLE
Amended the new GNSS Fix2 message with ECEF velocity field

### DIFF
--- a/uavcan/equipment/gnss/1063.Fix2.uavcan
+++ b/uavcan/equipment/gnss/1063.Fix2.uavcan
@@ -50,7 +50,7 @@ uint2 status
 
 #
 # GNSS Mode
-# 
+#
 uint4 MODE_SINGLE      = 0
 uint4 MODE_DGPS        = 1
 uint4 MODE_RTK         = 2
@@ -78,6 +78,6 @@ float16[<=36] covariance    # Position and velocity covariance. Units are
 float16 pdop
 
 #
-# Position solution in ECEF
+# Position and velocity solution in ECEF, if available
 #
-ECEFPosition[<=1] ecef_position
+ECEFPositionVelocity[<=1] ecef_position_velocity

--- a/uavcan/equipment/gnss/ECEFPositionVelocity.uavcan
+++ b/uavcan/equipment/gnss/ECEFPositionVelocity.uavcan
@@ -1,6 +1,6 @@
 #
 # Nested type.
-# GNSS ECEF high precision position and velocity.
+# GNSS ECEF high resolution position and velocity.
 #
 # ECEF is an acronym for Earth-Centered-Earth-Fixed, which is a cartesian
 # coordinate system which rotates with the earth. The origin (0,0,0) is
@@ -11,8 +11,11 @@
 # right-handed coordinate system.
 #
 
+float32[3] velocity_xyz            # XYZ velocity in m/s
+
 int36[3] position_xyz_mm           # XYZ-axis coordinates in mm
 
-void4                              # Padding to make this field a multiple of 8 bits
+void6                              # Aligns the following array at byte boundary
 
-float32[3] velocity_xyz            # XYZ velocity in m/s
+float16[<=36] covariance           # Position and velocity covariance in the ECEF frame. Units are m^2 for position,
+                                   # (m/s)^2 for velocity, and m^2/s for position/velocity.

--- a/uavcan/equipment/gnss/ECEFPositionVelocity.uavcan
+++ b/uavcan/equipment/gnss/ECEFPositionVelocity.uavcan
@@ -1,6 +1,6 @@
 #
 # Nested type.
-# GNSS ECEF status field.
+# GNSS ECEF high precision position and velocity.
 #
 # ECEF is an acronym for Earth-Centered-Earth-Fixed, which is a cartesian
 # coordinate system which rotates with the earth. The origin (0,0,0) is
@@ -11,6 +11,8 @@
 # right-handed coordinate system.
 #
 
-int36[3] xyz_mm                    # XYZ-axis coordinates in mm
+int36[3] position_xyz_mm           # XYZ-axis coordinates in mm
 
 void4                              # Padding to make this field a multiple of 8 bits
+
+float32[3] velocity_xyz            # XYZ velocity in m/s


### PR DESCRIPTION
@glennib @WickedShell This PR extends the recently added message type `uavcan.equipment.gnss.Fix2` with an ECEF velocity field for completeness. I am going to merge it tomorrow unless you find anything wrong with these changes.

The ECEF velocity is represented in meters per second as a float32 triplet.

Normally we shouldn't modify data types that have already been merged into master, but this time we can deviate for two reasons:

1. There has been no official release of the DSDL set yet.
2. The new Fix2 message type is not yet used in production (this will change in a week once we've released the new Zubax GNSS v2.2 which will support both Fix and Fix2).