### PR TITLE
Added message 1002.MagneticFieldStrength2.uavcan

### DIFF
--- a/uavcan/equipment/ahrs/1002.MagneticFieldStrength2.uavcan
+++ b/uavcan/equipment/ahrs/1002.MagneticFieldStrength2.uavcan
@@ -1,8 +1,9 @@
 #
 # Magnetic field readings, in Gauss, in body frame.
 # SI units are avoided because of float16 range limitations.
-# This message is deprecated. Use the newer 1002.MagneticFieldStrength2.uavcan message.
 #
+
+uint8 sensor_id
 
 float16[3] magnetic_field_ga
 float16[<=9] magnetic_field_covariance


### PR DESCRIPTION
New message based on 1001.MagneticFieldStrength with new field sensor_id, which can be used if your node has more then one sensor.