### PR TITLE
Add raw airspeed differential press and temp message

### DIFF
--- a/uavcan/equipment/air_data/1027.RawAirData.uavcan
+++ b/uavcan/equipment/air_data/1027.RawAirData.uavcan
@@ -1,0 +1,41 @@
+#
+# Raw Air Data.
+#
+
+# Note: unused vars should be assigned NaN
+
+#
+# Heater State
+# 
+uint8 FLAG_HEATER_AVAILABLE      = 1
+uint8 FLAG_HEATER_WORKING        = 2
+uint8 FLAG_HEATER_OVERCURRENT    = 4
+uint8 FLAG_HEATER_OPENCIRCUIT    = 8
+uint8 flags
+
+#
+# Pressure Data
+#
+float32 static_pressure                 # Pascal
+float32 differential_pressure           # Pascal
+
+#
+# Temperature Data
+#
+float16 static_pressure_sensor_temperature          # Kelvin
+float16 differential_pressure_sensor_temperature    # Kelvin
+
+float16 static_air_temperature          # Kelvin
+                                        # This field contains the raw temperature reading 
+                                        # from the externally mounted temperature sensor or, 
+                                        # in absence of one, the raw temperature of the pressure sensor.
+
+float16 pitot_temperature               # Kelvin
+
+
+float16[<=16] covariance                # order of diagonal elements : 
+                                        # static_pressure, differential_pressure,
+                                        # static_air_temperature, pitot_temperature
+                                        # Pascal^2 for pressure variance and covariance
+                                        # Kevin^2 for Temperature variance and covariance
+                                        # Pascal*Kelvin for pressure/temperature covariance


### PR DESCRIPTION
This PR adds Raw Airspeed Data message for use in transmitting the differential pressure and temperature directly to Autopilot or any other consumer where it will be converted into True Airspeed.