### PR TITLE
Foreign object

### DIFF
--- a/uavcan/foreign_object/Buffer1024.uavcan
+++ b/uavcan/foreign_object/Buffer1024.uavcan
@@ -1,0 +1,5 @@
+#
+# Buffer that is used to keep serialized object in a specified format.
+#
+
+uint8[<=1024] buffer

--- a/uavcan/foreign_object/Destination.uavcan
+++ b/uavcan/foreign_object/Destination.uavcan
@@ -1,0 +1,7 @@
+#
+# Use this nested type to create unicast-addressable messages.
+#
+
+void1
+uint7 NODE_ID_BROADCAST = 0
+uint7 node_id

--- a/uavcan/foreign_object/Format.uavcan
+++ b/uavcan/foreign_object/Format.uavcan
@@ -1,0 +1,9 @@
+#
+# This enumeration defines the serialization format used to encode the object.
+#
+
+uint8 RAW                       = 0     # Raw data, no encoding
+uint8 BSON                      = 1     # BSON
+uint8 CAPNPROTO                 = 2     # CAP'N PROTO
+
+uint8 format

--- a/uavcan/foreign_object/Format.uavcan
+++ b/uavcan/foreign_object/Format.uavcan
@@ -5,5 +5,7 @@
 uint8 RAW                       = 0     # Raw data, no encoding
 uint8 BSON                      = 1     # BSON
 uint8 CAPNPROTO                 = 2     # CAP'N PROTO
+uint8 MAVLINK                   = 3     # MAVLink
+uint8 PROTOBUF                  = 4     # ProtoBuf
 
 uint8 format

--- a/uavcan/foreign_object/Name.uavcan
+++ b/uavcan/foreign_object/Name.uavcan
@@ -1,0 +1,6 @@
+#
+# Object name as a UTF-8 string
+#
+
+void1
+uint8[<=80] name


### PR DESCRIPTION
This closes issue https://github.com/UAVCAN/dsdl/issues/3.

Add a foreign object packet type that includes a format for:
RAW
BSON
CAPNPROTO
MAVLINK
PROTOBUF

My main goal is to get MAVLink over UAVCAN for a flight controller that only has CAN attached to it (no serial) so a GCS can at least communicate with it without reinventing all of MAVlink cmds over CAN.