### PR TITLE
Tunneling: reduce buffer and add 4bit ChannelID

### DIFF
--- a/uavcan/tunnel/2010.Broadcast.uavcan
+++ b/uavcan/tunnel/2010.Broadcast.uavcan
@@ -2,8 +2,9 @@
 # This message struct carries arbitrary data in the format of the specified high-level protocol.
 # The data will be delivered to all nodes that are interested in tunneled protocols.
 # Finer addressing schemes may be implemented using the means provided by the encapsulated protocol.
-#
+# The channelID allows for additional routing between the source and target nodes.
 
 Protocol protocol
+uint4 channelID
 
-uint8[<=1024] buffer    # TAO rules apply
+uint8[<=60] buffer    # TAO rules apply

--- a/uavcan/tunnel/63.Call.uavcan
+++ b/uavcan/tunnel/63.Call.uavcan
@@ -2,13 +2,15 @@
 # This service carries arbitrary data in the format of the specified high-level protocol.
 # The data will be delivered to the specified node only (not broadcast), and the addressed node
 # will be required to respond (although the response may be empty, if the chosen protocol allows so).
-# The specified protocol applies both to the request and to the response.
+# The specified protocol applies both to the request and to the response. The channelID allows for
+# additional routing between the source and target nodes.
 #
 
 Protocol protocol
+uint4 channelID
 
-uint8[<=1024] buffer    # TAO rules apply
+uint8[<=60] buffer    # TAO rules apply
 
 ---
 
-uint8[<=1024] buffer    # TAO rules apply
+uint8[<=60] buffer    # TAO rules apply

--- a/uavcan/tunnel/Protocol.uavcan
+++ b/uavcan/tunnel/Protocol.uavcan
@@ -3,6 +3,6 @@
 # New protocols are likely to be added in the future.
 #
 
-uint8 MAVLINK                   = 0     # MAVLink
+uint4 MAVLINK                   = 0     # MAVLink
 
-uint8 protocol
+uint4 protocol


### PR DESCRIPTION
duplicate of https://github.com/UAVCAN/dsdl/pull/42 but with 4bit protocol/channelID

- reduce buffer from 1024 to 60
- add 4bit ChannelID for routing
- reduce Protocol enum from 8 bits to 4 bits

This effects uavcan.tunnel.Broadcast and tunnel.Call

The buffer.size was reduced because 1024 is unnecessarily huge. For embedded systems that is too much to do on the fly on every packet.

The number 60 was chosen so that a whole packet could fit into a single CANfd frame.

ChannelID was chosen so that, in the case of a virtual tunnel, multiple paths could exist between nodes. That is, if we were to treat this as a virtual COM port, we could have 256 "COM ports" talking to any 256 on the other end.

protocol enum changing to 4bit is so that Protocol + channelID + buffer[60] fit in CANfd. With 8bit protocol we would need buffer.size 59... and that's silly!