### PR TITLE
Assertion checks, CI is back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "3.6"
 before_install:
-  - pip install 'uavcan>=1.0.0.dev27'
+  - pip install pydsdl
 script:
-  - python3 test.py
+  - ./test.py

--- a/test.py
+++ b/test.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
 
 import sys
-import logging
+import pydsdl
 
-logging.basicConfig(stream=sys.stderr, level='DEBUG', format='%(levelname)s: %(message)s')
+output = pydsdl.parse_namespace('uavcan', [])
 
-from uavcan import dsdl
-
-parsed = dsdl.parse_namespaces(['uavcan']);
-if parsed:
-    logging.info('%d data types parsed successfully', len(parsed))
+print('\n'.join(map(str, output)))

--- a/test.py
+++ b/test.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
 
 import sys
+import time
 import pydsdl
 
-output = pydsdl.parse_namespace('uavcan', [])
+def on_print(definition, line, value):
+    print('%s:%d: %s' % (definition.file_path, line, value), file=sys.stderr)
+
+started_at = time.monotonic()
+
+output = pydsdl.parse_namespace('uavcan', [], print_directive_output_handler=on_print)
+
+elapsed_time = time.monotonic() - started_at
 
 print('\n'.join(map(str, output)))
+
+print('%d data types in %.1f seconds' % (len(output), elapsed_time), file=sys.stderr)

--- a/uavcan/internet/udp/500.HandleIncomingPacket.0.1.uavcan
+++ b/uavcan/internet/udp/500.HandleIncomingPacket.0.1.uavcan
@@ -40,6 +40,8 @@ uint16 session_id
 void7
 uint8[<=320] payload
 
+@assert offset % 8 == {0}
+
 ---
 
 # If the service invocation times out, the modem node is permitted to remove the corresponding entry from

--- a/uavcan/internet/udp/65510.OutgoingPacket.0.1.uavcan
+++ b/uavcan/internet/udp/65510.OutgoingPacket.0.1.uavcan
@@ -131,3 +131,5 @@ uint8[<=45] destination_address
 # communication equipment. Refer to RFC 791 and 2460 for an in-depth review.
 # UAVCAN further limits the maximum packet size to reduce the memory and traffic burden on the nodes.
 uint8[<256] payload
+
+@assert offset % 8 == {0}

--- a/uavcan/node/430.GetInfo.0.1.uavcan
+++ b/uavcan/node/430.GetInfo.0.1.uavcan
@@ -28,7 +28,7 @@ Version.1 software_version
 # For example, this field can be used for reporting the short git commit hash of the current
 # software revision.
 # Set to zero if not used.
-truncated uint64 software_vcs_revision_id
+uint64 software_vcs_revision_id
 
 # The unique node ID is a 128-bit long sequence that is likely to be globally unique per node.
 # The vendor must ensure that the probability of a collision with any other node UID globally is negligibly low.
@@ -38,6 +38,7 @@ truncated uint64 software_vcs_revision_id
 uint8[16] unique_id
 
 # Manual serialization note: only fixed-size fields up to this point. The following fields are dynamically sized.
+@assert offset == {37 * 8}
 
 # Human-readable non-empty ASCII node name. An empty name is not permitted.
 # The name must not be changed while the node is running.
@@ -67,3 +68,5 @@ uint64[<=1] software_image_crc
 # E.g., this field can be used for reporting RSA signatures (up to RSA-2040).
 # Leave empty if not used. Not to be changed while the node is runnning.
 uint8[<256] certificate_of_authenticity
+
+@assert offset % 8 == {0}

--- a/uavcan/node/431.GetPorts.0.1.uavcan
+++ b/uavcan/node/431.GetPorts.0.1.uavcan
@@ -29,7 +29,11 @@
 void7
 PortID.1 port_id_lower_boundary
 
+@assert offset == {24}
+
 ---
 
 # See above for the full description of the logic.
 uint16[<=128] port_ids
+
+@assert offset % 8 == {0}

--- a/uavcan/node/432.GetPortInfo.0.1.uavcan
+++ b/uavcan/node/432.GetPortInfo.0.1.uavcan
@@ -7,6 +7,8 @@
 void7
 PortID.1 port_id
 
+@assert offset == {24}
+
 ---
 
 # Flags describing the current port.
@@ -24,3 +26,5 @@ uint8[<64] data_type_full_name
 
 # The version numbers of the data type used at this port.
 Version.1 data_type_version
+
+@assert offset % 8 == {0}

--- a/uavcan/node/433.GetPortStatistics.0.1.uavcan
+++ b/uavcan/node/433.GetPortStatistics.0.1.uavcan
@@ -7,6 +7,8 @@
 void7
 PortID.1 port_id
 
+@assert offset == {24}
+
 ---
 
 # For messages, "emitted" applies to publications, and "received" applies to subscribers.
@@ -22,3 +24,5 @@ PortID.1 port_id
 # call was processed properly, but the application could not act upon that data, it should not be
 # reported here because that problem should be attributed to a different level of abstraction.
 IOStatistics.0 statistics
+
+@assert offset % 8 == {0}

--- a/uavcan/node/434.GetTransportStatistics.0.1.uavcan
+++ b/uavcan/node/434.GetTransportStatistics.0.1.uavcan
@@ -14,3 +14,5 @@ IOStatistics.0 transfer_statistics
 # the one at the index zero would apply to the first interface, the other to the second interface.
 void6
 IOStatistics.0[<=3] physical_interface_statistics
+
+@assert offset % 8 == {0}

--- a/uavcan/node/435.ExecuteCommand.0.1.uavcan
+++ b/uavcan/node/435.ExecuteCommand.0.1.uavcan
@@ -54,6 +54,8 @@ uint16 COMMAND_STORE_PERSISTENT_STATES = 65530
 #   - COMMAND_BEGIN_SOFTWARE_UPDATE
 uint8[<=200] parameter
 
+@assert offset % 8 == {0}
+
 ---
 
 # The result of the request.

--- a/uavcan/node/62805.Heartbeat.1.0.uavcan
+++ b/uavcan/node/62805.Heartbeat.1.0.uavcan
@@ -67,3 +67,6 @@ uint3 MODE_OFFLINE          = 7
 
 # Optional, vendor-specific node status code, e.g. a fault code or a status bitmask.
 truncated uint19 vendor_specific_status_code
+
+@assert offset % 8 == {0}
+@assert offset.max <= 56    # Must fit into one CAN 2.0 frame (least capable transport, smallest MTU)

--- a/uavcan/node/PortID.1.0.uavcan
+++ b/uavcan/node/PortID.1.0.uavcan
@@ -4,5 +4,6 @@
 #
 
 @union
-uint9  service_id
-uint16 subject_id
+ServiceID.1 service_id
+SubjectID.1 subject_id
+@assert offset == {17}

--- a/uavcan/node/ServiceID.1.0.uavcan
+++ b/uavcan/node/ServiceID.1.0.uavcan
@@ -1,0 +1,10 @@
+#
+# Service ID. The ranges are defined by the specification.
+#
+
+uint9 MAX_UNREGULATED_ID = 127
+
+void7
+uint9 value
+
+@assert offset == {16}

--- a/uavcan/node/SubjectID.1.0.uavcan
+++ b/uavcan/node/SubjectID.1.0.uavcan
@@ -1,0 +1,7 @@
+#
+# Subject ID. The ranges are defined by the specification.
+#
+
+uint16 MAX_UNREGULATED_ID = 32767
+
+uint16 value

--- a/uavcan/pnp/65534.NodeIDAllocationData.0.1.uavcan
+++ b/uavcan/pnp/65534.NodeIDAllocationData.0.1.uavcan
@@ -97,3 +97,5 @@ void1
 # and ignore the message if there is no match. If the IDs match, then the field node_id contains the
 # allocated node ID value for this node.
 uint8[16] unique_id
+
+@assert offset % 8 == {0}

--- a/uavcan/pnp/server/390.AppendEntries.1.0.uavcan
+++ b/uavcan/pnp/server/390.AppendEntries.1.0.uavcan
@@ -28,6 +28,8 @@ uint8 leader_commit
 void7
 Entry.1[<=1] entries
 
+@assert offset % 8 == {0}
+
 ---
 
 # Refer to the Raft paper for explanation.

--- a/uavcan/pnp/server/62810.ClusterDiscovery.1.0.uavcan
+++ b/uavcan/pnp/server/62810.ClusterDiscovery.1.0.uavcan
@@ -22,3 +22,5 @@ uint3 configured_cluster_size
 # The cluster cannot contain more than 5 servers.
 void2
 uint8[<=5] known_nodes
+
+@assert offset % 8 == {0}

--- a/uavcan/pnp/server/Entry.1.0.uavcan
+++ b/uavcan/pnp/server/Entry.1.0.uavcan
@@ -10,3 +10,5 @@ uint8[16] unique_id     # Unique ID of this allocation.
 
 void1
 uint7 node_id           # Node ID of this allocation.
+
+@assert offset % 8 == {0}

--- a/uavcan/time/62804.Synchronization.1.0.uavcan
+++ b/uavcan/time/62804.Synchronization.1.0.uavcan
@@ -17,3 +17,6 @@ uint8 PUBLISHER_TIMEOUT_PERIOD_MULTIPLIER = 3
 # The time when the PREVIOUS message was transmitted from the current publisher.
 # If this message is published for the first time, this field must be zero.
 Point.1 previous_transmission_timestamp
+
+@assert offset % 8 == {0}
+@assert offset.max <= 56    # Must fit into one CAN 2.0 frame (least capable transport, smallest MTU)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3298404/47812062-02450500-dd50-11e8-860e-2cd13c338c53.png)

PyDSDL version 0.1.0 is out: https://github.com/UAVCAN/pydsdl (also available on PyPI)
PyDSDL can do clever checks as proposed here by @kjetilkjeka (using exactly that syntax): https://forum.uavcan.org/t/new-dsdl-directive-for-simple-compile-time-checks/190/13 (not yet described in the specification, soon to be)

I fully comprehended the value of static checks only when I started using them myself here: they helped me to uncover a bit alignment issue in the `PortID` definition, which I promptly fixed. Luckily, this is a staging branch, so breaking changes are still possible, otherwise it would be a problem. Also, it is no longer necessary to go over each definition meticulously adding bits together to make sure everything is aligned properly, which is a really huge relief: you can just drop in `@assert offset % 8 == {0}`, and the parser (compiler) will statically prove that none of the possible valid combinations of preceding fields can produce an offset that is not byte-aligned.

For example, the set of bit length values for all valid encoded representations of `uavcan.node.GetInfo.Response` is: <sub>320, 328, 336, 344, 352, 360, 368, 376, 384, 392, 400, 408, 416, 424, 432, 440, 448, 456, 464, 472, 480, 488, 496, 504, 512, 520, 528, 536, 544, 552, 560, 568, 576, 584, 592, 600, 608, 616, 624, 632, 640, 648, 656, 664, 672, 680, 688, 696, 704, 712, 720, 728, 736, 744, 752, 760, 768, 776, 784, 792, 800, 808, 816, 824, 832, 840, 848, 856, 864, 872, 880, 888, 896, 904, 912, 920, 928, 936, 944, 952, 960, 968, 976, 984, 992, 1000, 1008, 1016, 1024, 1032, 1040, 1048, 1056, 1064, 1072, 1080, 1088, 1096, 1104, 1112, 1120, 1128, 1136, 1144, 1152, 1160, 1168, 1176, 1184, 1192, 1200, 1208, 1216, 1224, 1232, 1240, 1248, 1256, 1264, 1272, 1280, 1288, 1296, 1304, 1312, 1320, 1328, 1336, 1344, 1352, 1360, 1368, 1376, 1384, 1392, 1400, 1408, 1416, 1424, 1432, 1440, 1448, 1456, 1464, 1472, 1480, 1488, 1496, 1504, 1512, 1520, 1528, 1536, 1544, 1552, 1560, 1568, 1576, 1584, 1592, 1600, 1608, 1616, 1624, 1632, 1640, 1648, 1656, 1664, 1672, 1680, 1688, 1696, 1704, 1712, 1720, 1728, 1736, 1744, 1752, 1760, 1768, 1776, 1784, 1792, 1800, 1808, 1816, 1824, 1832, 1840, 1848, 1856, 1864, 1872, 1880, 1888, 1896, 1904, 1912, 1920, 1928, 1936, 1944, 1952, 1960, 1968, 1976, 1984, 1992, 2000, 2008, 2016, 2024, 2032, 2040, 2048, 2056, 2064, 2072, 2080, 2088, 2096, 2104, 2112, 2120, 2128, 2136, 2144, 2152, 2160, 2168, 2176, 2184, 2192, 2200, 2208, 2216, 2224, 2232, 2240, 2248, 2256, 2264, 2272, 2280, 2288, 2296, 2304, 2312, 2320, 2328, 2336, 2344, 2352, 2360, 2368, 2376, 2384, 2392, 2400, 2408, 2416, 2424, 2432, 2440, 2448, 2456, 2464, 2472, 2480, 2488, 2496, 2504, 2512, 2520, 2528, 2536, 2544, 2552, 2560, 2568, 2576, 2584, 2592, 2600, 2608, 2616, 2624, 2632, 2640, 2648, 2656, 2664, 2672, 2680, 2688, 2696, 2704, 2712, 2720, 2728, 2736, 2744, 2752, 2760, 2768, 2776, 2784, 2792, 2800, 2808, 2816, 2824, 2832, 2840, 2848, 2856, 2864, 2872, 2880, 2888, 2896, 2904, 2912, 2920, 2928</sub>. 