### PR TITLE
Renamed the CAN2.0-optimized allocation message

### DIFF
--- a/uavcan/pnp/65534.NodeIDAllocationData.0.1.uavcan
+++ b/uavcan/pnp/65534.NodeIDAllocationData.0.1.uavcan
@@ -1,7 +1,8 @@
 #
-# This message is used for dynamic node ID allocation on all transports except CAN 2.0.
-# For CAN 2.0 there is a dedicated message definition that takes into account the limitations of that transport,
-# making the allocation protocol much more complex.
+# This message is used for dynamic node ID allocation on all transports where the maximum transmission unit
+# size is at least 18 bytes (which excludes CAN2.0).
+# For low-MTU transports such as CAN2.0 there is a dedicated message definition that takes into account the
+# limitations of that transport, making the allocation protocol much more complex.
 #
 # When a node needs to request a node ID dynamically, it will transmit an anonymous message transfer of this type.
 #
@@ -99,3 +100,4 @@ void1
 uint8[16] unique_id
 
 @assert offset % 8 == {0}
+@assert offset.max / 8 == 17    # Plus the tail byte yields 18

--- a/uavcan/pnp/65535.NodeIDAllocationDataMTU8.0.1.uavcan
+++ b/uavcan/pnp/65535.NodeIDAllocationDataMTU8.0.1.uavcan
@@ -1,6 +1,8 @@
 #
-# This message is used for dynamic node ID allocation on CAN 2.0 based transports.
-# For other kinds of transports there is a generic, much simpler and more capable definition.
+# The suffix "MTU8" indicates that this message is made to be compatible with transports where the maximum
+# transmission unit size is only 8 bytes, such as CAN 2.0.
+# For other kinds of transports there is a generic, much simpler and more capable definition; it can't be
+# used with low-MTU transports, hence the need for this special case definition.
 #
 # When a node needs to request a node ID dynamically, it will transmit an anonymous message transfer of this type.
 #


### PR DESCRIPTION
The transport doesn't matter, MTU does. Updated the comments accordingly.