### PR TITLE
Explicitly providing minor version for all nested types

### DIFF
--- a/uavcan/diagnostic/65520.Record.1.0.uavcan
+++ b/uavcan/diagnostic/65520.Record.1.0.uavcan
@@ -5,10 +5,10 @@
 
 # Optional timestamp in the network-synchronized time system; zero if undefined.
 # The timestamp value conveys the exact moment when the reported event took place.
-uavcan.time.SynchronizedTimestamp.1 timestamp
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
 
 # Standard severity, 3 bit wide.
-Severity.1 severity
+Severity.1.0 severity
 
 # Short name of the message source within the publishing node.
 uint8[<32] source

--- a/uavcan/file/405.GetInfo.0.1.uavcan
+++ b/uavcan/file/405.GetInfo.0.1.uavcan
@@ -2,12 +2,12 @@
 # Information about a remote file system entry (file, directory, etc).
 #
 
-Path.1 path
+Path.1.0 path
 
 ---
 
 # Result of the operation
-Error.1 error
+Error.1.0 error
 
 # File size in bytes. Should be set to zero for directories.
 truncated uint40 size

--- a/uavcan/file/406.ListDirectory.0.1.uavcan
+++ b/uavcan/file/406.ListDirectory.0.1.uavcan
@@ -20,7 +20,7 @@ uint32 entry_index
 
 void32                  # Reserved for future use
 
-Path.1 directory_path
+Path.1.0 directory_path
 
 @assert offset % 8 == {0}
 
@@ -35,6 +35,6 @@ void32                  # Reserved for future use
 # For example, suppose there is a file "/foo/bar/baz.bin". Listing the directory with the path "/foo/bar/" (the slash
 # at the end is optional) at the index 0 will return "baz.bin". Listing the same directory at the index 1 (or any
 # higher) will return an empty name "", indicating that the caller has reached the end of the list.
-Path.1 entry_base_name
+Path.1.0 entry_base_name
 
 @assert offset % 8 == {0}

--- a/uavcan/file/407.Modify.1.0.uavcan
+++ b/uavcan/file/407.Modify.1.0.uavcan
@@ -38,13 +38,13 @@ bool preserve_source            # Do not remove the source. Used to copy instead
 bool overwrite_destination      # If the destination exists, remove it beforehand.
 void30
 
-Path.1 source
-Path.1 destination
+Path.1.0 source
+Path.1.0 destination
 
 @assert offset % 8 == {0}
 
 ---
 
-Error.1 error
+Error.1.0 error
 
 @assert offset % 8 == {0}

--- a/uavcan/file/408.Read.1.0.uavcan
+++ b/uavcan/file/408.Read.1.0.uavcan
@@ -31,13 +31,13 @@
 
 truncated uint40 offset
 
-Path.1 path
+Path.1.0 path
 
 @assert offset % 8 == {0}
 
 ---
 
-Error.1 error
+Error.1.0 error
 
 void7
 uint8[<=256] data

--- a/uavcan/file/409.Write.1.0.uavcan
+++ b/uavcan/file/409.Write.1.0.uavcan
@@ -13,7 +13,7 @@
 
 truncated uint40 offset
 
-Path.1 path
+Path.1.0 path
 
 uint8[<=128] data
 
@@ -22,4 +22,4 @@ uint8[<=128] data
 
 ---
 
-Error.1 error
+Error.1.0 error

--- a/uavcan/node/430.GetInfo.0.1.uavcan
+++ b/uavcan/node/430.GetInfo.0.1.uavcan
@@ -10,19 +10,19 @@
 # This is the same value that is periodically published by the node.
 # The objective of its inclusion here is to ensure that the node did not restart since the last time
 # this message was received from it, because a restart may invalidate the node information.
-Heartbeat.1 most_recent_heartbeat
+Heartbeat.1.0 most_recent_heartbeat
 
 # The UAVCAN protocol version implemented on this node, both major and minor.
 # Not to be changed while the node is running.
-Version.1 protocol_version
+Version.1.0 protocol_version
 
 # The version information must not be changed while the node is running.
 # The correct hardware version must be reported at all times, excepting software-only nodes, in which
 # case it should be set to zeros.
 # If the node is equipped with a UAVCAN-capable bootloader, the bootloader should report the software
 # version of the installed application, if there is any; if no application is found, zeros should be reported.
-Version.1 hardware_version
-Version.1 software_version
+Version.1.0 hardware_version
+Version.1.0 software_version
 
 # A version control system (VCS) revision number or hash. Not to be changed while the node is runnning.
 # For example, this field can be used for reporting the short git commit hash of the current

--- a/uavcan/node/431.GetPorts.0.1.uavcan
+++ b/uavcan/node/431.GetPorts.0.1.uavcan
@@ -27,7 +27,7 @@
 # no port ID that is lower than the greatest value in the returned array that is not listed in the array, because
 # in that case the client will never be able to obtain that value.
 void7
-PortID.1 port_id_lower_boundary
+PortID.1.0 port_id_lower_boundary
 
 @assert offset == {24}
 

--- a/uavcan/node/432.GetPortInfo.0.1.uavcan
+++ b/uavcan/node/432.GetPortInfo.0.1.uavcan
@@ -5,7 +5,7 @@
 
 # The port of interest; can be either a service or a message.
 void7
-PortID.1 port_id
+PortID.1.0 port_id
 
 @assert offset == {24}
 
@@ -25,6 +25,6 @@ void2
 uint8[<64] data_type_full_name
 
 # The version numbers of the data type used at this port.
-Version.1 data_type_version
+Version.1.0 data_type_version
 
 @assert offset % 8 == {0}

--- a/uavcan/node/433.GetPortStatistics.0.1.uavcan
+++ b/uavcan/node/433.GetPortStatistics.0.1.uavcan
@@ -5,7 +5,7 @@
 
 # The port of interest; can be either a service or a message.
 void7
-PortID.1 port_id
+PortID.1.0 port_id
 
 @assert offset == {24}
 
@@ -23,6 +23,6 @@ PortID.1 port_id
 # such incident should be reported here via this field. On the other hand, if the message or service
 # call was processed properly, but the application could not act upon that data, it should not be
 # reported here because that problem should be attributed to a different level of abstraction.
-IOStatistics.0 statistics
+IOStatistics.0.1 statistics
 
 @assert offset % 8 == {0}

--- a/uavcan/node/434.GetTransportStatistics.0.1.uavcan
+++ b/uavcan/node/434.GetTransportStatistics.0.1.uavcan
@@ -7,12 +7,12 @@
 
 # UAVCAN transfer performance statistics:
 # the number of UAVCAN transfers sent, received, and failed.
-IOStatistics.0 transfer_statistics
+IOStatistics.0.1 transfer_statistics
 
 # Physical interface statistics, separate per interface.
 # E.g. for a doubly redundant CAN bus interface, this array would contain two elements,
 # the one at the index zero would apply to the first interface, the other to the second interface.
 void6
-IOStatistics.0[<=3] physical_interface_statistics
+IOStatistics.0.1[<=3] physical_interface_statistics
 
 @assert offset % 8 == {0}

--- a/uavcan/node/PortID.1.0.uavcan
+++ b/uavcan/node/PortID.1.0.uavcan
@@ -4,6 +4,6 @@
 #
 
 @union
-ServiceID.1 service_id
-SubjectID.1 subject_id
+ServiceID.1.0 service_id
+SubjectID.1.0 subject_id
 @assert offset == {17}

--- a/uavcan/pnp/server/390.AppendEntries.1.0.uavcan
+++ b/uavcan/pnp/server/390.AppendEntries.1.0.uavcan
@@ -26,7 +26,7 @@ uint8 leader_commit
 # Worst-case replication time per Follower can be computed as:
 #   worst replication time = (127 log entries) * (2 trips of next_index) * (request interval per Follower)
 void7
-Entry.1[<=1] entries
+Entry.1.0[<=1] entries
 
 @assert offset % 8 == {0}
 


### PR DESCRIPTION
I have updated the PyDSDL parser to require minor version as discussed here:

- https://github.com/UAVCAN/pydsdl/issues/5
- https://forum.uavcan.org/t/the-case-for-code-compatibility/194/12

The new PyDSDL version 0.2 is already released, which means that the CI in this repo will now require minor version as well.