### PR TITLE
DSDL actualization: subject ID range review; offset --> _offset_

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Refer to the specification for background information and motivation.
 For message subjects, the following range mapping is adopted (limits inclusive).
 Unused ranges are reserved for future expansion of adjacent ranges.
 
-From    | To        | Purpose
+From    | To        | Capacity | Purpose
 --------|-----------|------------------------------------------------
-0       | 32767     | Unregulated identifiers
-57344   | 59391     | Non-standard (vendor-specific) regulated identifiers
-62804   | 65535     | Standard regulated identifiers
+0       | 24575     | 24576    | Unregulated identifiers
+28672   | 29695     | 1024     | Non-standard (vendor-specific) regulated identifiers
+31744   | 32767     | 1024     | Standard regulated identifiers
 
 ### Services
 
@@ -60,11 +60,14 @@ Ordered by priority from high to low.
 
 Namespace                   | Lower bound (inclusive)
 ----------------------------|-------------------------
-`uavcan.time`               | 62804
-`uavcan.node`               | 62805
-`uavcan.pnp`                | 62810/65533
-`uavcan.internet`           | 65510
-`uavcan.diagnostic`         | 65520
+`uavcan.time`               | 31744
+`uavcan.node`               | 32085
+`uavcan.pnp`                | 32740
+`uavcan.internet`           | 32750
+`uavcan.diagnostic`         | 32760
+
+The value 32085 contains the longest possible sequence of alternating bits,
+which can be leveraged for automatic bit rate detection (depending on the physical layer).
 
 #### Services
 

--- a/uavcan/diagnostic/32760.Record.1.0.uavcan
+++ b/uavcan/diagnostic/32760.Record.1.0.uavcan
@@ -15,5 +15,5 @@ Severity.1.0 severity
 void6
 uint8[<=112] text
 
-@assert offset % 8 == {0}
-@assert offset.max <= (124 * 8)     # Two CAN FD frames max
+@assert _offset_ % 8 == {0}
+@assert _offset_.max <= (124 * 8)     # Two CAN FD frames max

--- a/uavcan/file/405.GetInfo.0.1.uavcan
+++ b/uavcan/file/405.GetInfo.0.1.uavcan
@@ -25,4 +25,4 @@ void4
 # Reserved for future use
 void64
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/file/406.List.0.1.uavcan
+++ b/uavcan/file/406.List.0.1.uavcan
@@ -22,7 +22,7 @@ void32                  # Reserved for future use
 
 Path.1.0 directory_path
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}
 
 ---
 
@@ -37,4 +37,4 @@ void32                  # Reserved for future use
 # higher) will return an empty name "", indicating that the caller has reached the end of the list.
 Path.1.0 entry_base_name
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/file/407.Modify.1.0.uavcan
+++ b/uavcan/file/407.Modify.1.0.uavcan
@@ -41,10 +41,10 @@ void30
 Path.1.0 source
 Path.1.0 destination
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}
 
 ---
 
 Error.1.0 error
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/file/408.Read.1.0.uavcan
+++ b/uavcan/file/408.Read.1.0.uavcan
@@ -33,7 +33,7 @@ truncated uint40 offset
 
 Path.1.0 path
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}
 
 ---
 
@@ -42,4 +42,4 @@ Error.1.0 error
 void7
 uint8[<=256] data
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/file/409.Write.1.0.uavcan
+++ b/uavcan/file/409.Write.1.0.uavcan
@@ -17,8 +17,8 @@ Path.1.0 path
 
 uint8[<=128] data
 
-@assert offset % 8 == {0}
-@assert offset.max / 8 <= 300
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 <= 300
 
 ---
 

--- a/uavcan/file/Path.1.0.uavcan
+++ b/uavcan/file/Path.1.0.uavcan
@@ -17,4 +17,4 @@ uint8 SEPARATOR = '/'
 void1
 uint8[<=112] path
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/internet/udp/32750.OutgoingPacket.0.1.uavcan
+++ b/uavcan/internet/udp/32750.OutgoingPacket.0.1.uavcan
@@ -132,4 +132,4 @@ uint8[<=45] destination_address
 # UAVCAN further limits the maximum packet size to reduce the memory and traffic burden on the nodes.
 uint8[<256] payload
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/internet/udp/500.HandleIncomingPacket.0.1.uavcan
+++ b/uavcan/internet/udp/500.HandleIncomingPacket.0.1.uavcan
@@ -40,8 +40,8 @@ uint16 session_id
 void7
 uint8[<=309] payload
 
-@assert offset % 8 == {0}
-@assert offset.max == (313 * 8)     # At most five CAN FD frames
+@assert _offset_ % 8 == {0}
+@assert _offset_.max == (313 * 8)     # At most five CAN FD frames
 
 ---
 

--- a/uavcan/node/32085.Heartbeat.1.0.uavcan
+++ b/uavcan/node/32085.Heartbeat.1.0.uavcan
@@ -4,9 +4,9 @@
 # All UAVCAN nodes are required to publish this message periodically.
 # This is the only high-level function that must be implemented by all nodes.
 #
-# The default subject ID 62805 is 1111010101010101 in binary. The alternating bit pattern at the end
+# The default subject ID 32085 is 111110101010101 in binary. The alternating bit pattern at the end
 # helps transceiver synchronization (e.g., on CAN-based networks) and on some transports permits
-# automatic bit rate detection (e.g., CAN bus).
+# automatic bit rate detection.
 #
 
 # The publication period must not exceed this limit.
@@ -68,5 +68,5 @@ uint3 MODE_OFFLINE          = 7
 # Optional, vendor-specific node status code, e.g. a fault code or a status bitmask.
 truncated uint19 vendor_specific_status_code
 
-@assert offset % 8 == {0}
-@assert offset.max <= 56    # Must fit into one CAN 2.0 frame (least capable transport, smallest MTU)
+@assert _offset_ % 8 == {0}
+@assert _offset_.max <= 56    # Must fit into one CAN 2.0 frame (least capable transport, smallest MTU)

--- a/uavcan/node/430.GetInfo.0.1.uavcan
+++ b/uavcan/node/430.GetInfo.0.1.uavcan
@@ -32,7 +32,7 @@ uint64 software_vcs_revision_id
 uint8[16] unique_id
 
 # Manual serialization note: only fixed-size fields up to this point. The following fields are dynamically sized.
-@assert offset == {30 * 8}
+@assert _offset_ == {30 * 8}
 
 # Human-readable non-empty ASCII node name. An empty name is not permitted.
 # The name must not be changed while the node is running.
@@ -63,5 +63,5 @@ uint64[<=1] software_image_crc
 # Leave empty if not used. Not to be changed while the node is running.
 uint8[<=222] certificate_of_authenticity
 
-@assert offset % 8 == {0}
-@assert offset.max == (313 * 8)     # At most five CAN FD frames
+@assert _offset_ % 8 == {0}
+@assert _offset_.max == (313 * 8)     # At most five CAN FD frames

--- a/uavcan/node/434.GetTransportStatistics.0.1.uavcan
+++ b/uavcan/node/434.GetTransportStatistics.0.1.uavcan
@@ -15,5 +15,5 @@ IOStatistics.0.1 transfer_statistics
 void6
 IOStatistics.0.1[<=3] physical_interface_statistics
 
-@assert offset % 8 == {0}
-@assert offset.max <= (63 * 8)      # One CAN FD frame
+@assert _offset_ % 8 == {0}
+@assert _offset_.max <= (63 * 8)      # One CAN FD frame

--- a/uavcan/node/435.ExecuteCommand.0.1.uavcan
+++ b/uavcan/node/435.ExecuteCommand.0.1.uavcan
@@ -70,8 +70,8 @@ uint16 COMMAND_STORE_PERSISTENT_STATES = 65530
 void1
 uint8[<=112] parameter
 
-@assert offset % 8 == {0}
-@assert offset.max <= (124 * 8)     # Two CAN FD frames max
+@assert _offset_ % 8 == {0}
+@assert _offset_.max <= (124 * 8)     # Two CAN FD frames max
 
 ---
 

--- a/uavcan/node/ID.1.0.uavcan
+++ b/uavcan/node/ID.1.0.uavcan
@@ -1,9 +1,10 @@
 #
 # Defines a node ID.
-# Per the specification, node ID ranges from 0 to 127, inclusively.
+# The maximum valid value is dependent on the underlying transport layer.
+# Values lower than 128 are always valid for all transports.
+# Refer to the specification for more info.
 #
 
-void1
-uint7 value
+uint16 value
 
-@assert offset == {8}
+@assert _offset_ == {16}

--- a/uavcan/node/port/431.List.0.1.uavcan
+++ b/uavcan/node/port/431.List.0.1.uavcan
@@ -29,11 +29,11 @@
 void7
 ID.1.0 port_id_lower_boundary
 
-@assert offset == {24}
+@assert _offset_ == {24}
 
 ---
 
 # See above for the full description of the logic.
 uint16[<=128] port_ids
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/node/port/432.GetInfo.0.1.uavcan
+++ b/uavcan/node/port/432.GetInfo.0.1.uavcan
@@ -7,7 +7,7 @@
 void7
 ID.1.0 port_id
 
-@assert offset == {24}
+@assert _offset_ == {24}
 
 ---
 
@@ -27,4 +27,4 @@ uint8[<=50] data_type_full_name
 # The version numbers of the data type used at this port.
 uavcan.node.Version.1.0 data_type_version
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/node/port/433.GetStatistics.0.1.uavcan
+++ b/uavcan/node/port/433.GetStatistics.0.1.uavcan
@@ -7,7 +7,7 @@
 void7
 ID.1.0 port_id
 
-@assert offset == {24}
+@assert _offset_ == {24}
 
 ---
 
@@ -25,4 +25,4 @@ ID.1.0 port_id
 # reported here because that problem should be attributed to a different level of abstraction.
 uavcan.node.IOStatistics.0.1 statistics
 
-@assert offset == {15 * 8}      # 15 bytes max; this service is optimized for high-frequency polling
+@assert _offset_ == {15 * 8}      # 15 bytes max; this service is optimized for high-frequency polling

--- a/uavcan/node/port/ID.1.0.uavcan
+++ b/uavcan/node/port/ID.1.0.uavcan
@@ -6,4 +6,4 @@
 @union
 ServiceID.1.0 service_id
 SubjectID.1.0 subject_id
-@assert offset == {17}
+@assert _offset_ == {17}

--- a/uavcan/node/port/ServiceID.1.0.uavcan
+++ b/uavcan/node/port/ServiceID.1.0.uavcan
@@ -7,4 +7,4 @@ uint9 MAX_UNREGULATED_ID = 127
 void7
 uint9 value
 
-@assert offset == {16}
+@assert _offset_ == {16}

--- a/uavcan/node/port/SubjectID.1.0.uavcan
+++ b/uavcan/node/port/SubjectID.1.0.uavcan
@@ -2,6 +2,9 @@
 # Subject ID. The ranges are defined by the specification.
 #
 
-uint16 MAX_UNREGULATED_ID = 32767
+uint16 MAX_UNREGULATED_ID = 24575
 
-uint16 value
+void1
+uint15 value
+
+@assert _offset_ == {16}

--- a/uavcan/pnp/32741.NodeIDAllocationData.0.1.uavcan
+++ b/uavcan/pnp/32741.NodeIDAllocationData.0.1.uavcan
@@ -126,10 +126,10 @@
 # for any reason is recommended to emit a diagnostic message with a human-readable description of the problem.
 # For allocatees, the logic is described below.
 #
-# This message is used for PnP node-ID allocation on all transports where the maximum transmission unit
-# size is at least 18 bytes (which excludes CAN 2.0). For low-MTU transports such as CAN 2.0 there is a dedicated
-# message definition that takes into account the limitations of that transport (namely, the unique-ID value is
-# replaced with a short hash in order to fit the data into one low-MTU single-frame transfer).
+# This message is used for PnP node-ID allocation on all transports where the maximum transmission unit size is
+# sufficiently large. For low-MTU transports such as CAN 2.0 there is a dedicated message definition that takes into
+# account the limitations of that transport (namely, the unique-ID value is replaced with a short hash in order to
+# fit the data into one low-MTU single-frame transfer).
 #
 # When a node needs to request a PnP node-ID, it will transmit an anonymous message transfer of this type. The pseudo
 # node-ID value of the anonymous transfer should be populated with pseudorandom data as described in the UAVCAN
@@ -215,5 +215,5 @@ uavcan.node.ID.1.0 node_id
 # match, then the field node_id contains the allocated node-ID value for this node.
 uint8[16] unique_id
 
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 17    # Plus the tail byte yields 18
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 18

--- a/uavcan/pnp/32742.NodeIDAllocationDataMTU8.0.1.uavcan
+++ b/uavcan/pnp/32742.NodeIDAllocationDataMTU8.0.1.uavcan
@@ -60,5 +60,5 @@ truncated uint55 unique_id_hash
 # Must be populated in response messages.
 uavcan.node.ID.1.0[<=1] allocated_node_id
 
-@assert offset.min == 56        # Plus the tail byte yields 8 bytes; this is for requests only
-@assert offset.max == 64        # Responses are non-anonymous, so they can be multi-frame
+@assert _offset_.min == 56        # Plus the tail byte yields 8 bytes; this is for requests only
+@assert _offset_.max == 72        # Responses are non-anonymous, so they can be multi-frame

--- a/uavcan/pnp/cluster/32740.Discovery.1.0.uavcan
+++ b/uavcan/pnp/cluster/32740.Discovery.1.0.uavcan
@@ -23,4 +23,4 @@ uint3 configured_cluster_size
 void2
 uavcan.node.ID.1.0[<=5] known_nodes
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/pnp/cluster/390.AppendEntries.1.0.uavcan
+++ b/uavcan/pnp/cluster/390.AppendEntries.1.0.uavcan
@@ -15,8 +15,8 @@
 # node). Therefore, the Raft log is the allocation table itself.
 #
 # Since the maximum number of entries in the allocation table is limited by the range of node-ID values, the log
-# cannot contain more than 128 entries. Therefore, the snapshot transfer and log compaction functions are not required,
-# so they are not available in this implementation of the Raft algorithm.
+# capacity is bounded. Therefore, the snapshot transfer and log compaction functions are not required,
+# so they are not used in this implementation of the Raft algorithm.
 #
 # When an allocator becomes the leader of the Raft cluster, it checks if the Raft log contains an entry for its own
 # node-ID, and if it doesn't, the leader adds its own allocation entry to the log (the unique-ID can be replaced with
@@ -79,14 +79,17 @@ uint8 leader_commit
 
 # Worst case replication time per Follower can be computed as:
 #
-#   worst replication time = (128 log entries) * (2 trips of next_index) * (request interval per Follower)
+#   worst replication time = (node-ID capacity) * (2 trips of next_index) * (request interval per Follower)
 #
-# E.g., given the request interval of 0.5 seconds, the worst case replication time is 128*2*0.5 = 128 seconds.
+# E.g., given the request interval of 0.5 seconds, the worst case replication time for CAN bus is:
+#
+#   128 nodes * 2 trips * 0.5 seconds = 128 seconds.
+#
 # This is the amount of time it will take for a new Follower to reconstruct a full replica of the distributed log.
 void7
 Entry.1.0[<=1] entries
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}
 
 ---
 

--- a/uavcan/pnp/cluster/Entry.1.0.uavcan
+++ b/uavcan/pnp/cluster/Entry.1.0.uavcan
@@ -9,4 +9,4 @@ uint8[16] unique_id             # Unique-ID of this allocation; zero if unknown.
 
 uavcan.node.ID.1.0 node_id      # Node-ID of this allocation.
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/primitive/String.1.0.uavcan
+++ b/uavcan/primitive/String.1.0.uavcan
@@ -5,5 +5,5 @@
 
 uint8[<256] value
 
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 256
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 256

--- a/uavcan/primitive/Unstructured.1.0.uavcan
+++ b/uavcan/primitive/Unstructured.1.0.uavcan
@@ -4,5 +4,5 @@
 
 uint8[<256] value
 
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 256
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 256

--- a/uavcan/primitive/array/Bit.1.0.uavcan
+++ b/uavcan/primitive/array/Bit.1.0.uavcan
@@ -1,4 +1,4 @@
 void5
 bool[<=2032] value
-@assert offset.min == 16
-@assert offset.max == 2048      # 2032 bits + 11 bit length + 5 bit padding = 256 bytes
+@assert _offset_.min == 16
+@assert _offset_.max == 2048      # 2032 bits + 11 bit length + 5 bit padding = 256 bytes

--- a/uavcan/primitive/array/Integer16.1.0.uavcan
+++ b/uavcan/primitive/array/Integer16.1.0.uavcan
@@ -1,3 +1,3 @@
 int16[<=128] value
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/primitive/array/Integer32.1.0.uavcan
+++ b/uavcan/primitive/array/Integer32.1.0.uavcan
@@ -1,4 +1,4 @@
 void1
 int32[<=64] value
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/primitive/array/Integer64.1.0.uavcan
+++ b/uavcan/primitive/array/Integer64.1.0.uavcan
@@ -1,4 +1,4 @@
 void2
 int64[<=32] value
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/primitive/array/Integer8.1.0.uavcan
+++ b/uavcan/primitive/array/Integer8.1.0.uavcan
@@ -1,3 +1,3 @@
 int8[<256] value
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 256
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 256

--- a/uavcan/primitive/array/Natural16.1.0.uavcan
+++ b/uavcan/primitive/array/Natural16.1.0.uavcan
@@ -1,3 +1,3 @@
 uint16[<=128] value
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/primitive/array/Natural32.1.0.uavcan
+++ b/uavcan/primitive/array/Natural32.1.0.uavcan
@@ -1,4 +1,4 @@
 void1
 uint32[<=64] value
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/primitive/array/Natural64.1.0.uavcan
+++ b/uavcan/primitive/array/Natural64.1.0.uavcan
@@ -1,4 +1,4 @@
 void2
 uint64[<=32] value
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/primitive/array/Natural8.1.0.uavcan
+++ b/uavcan/primitive/array/Natural8.1.0.uavcan
@@ -1,3 +1,3 @@
 uint8[<256] value
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 256
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 256

--- a/uavcan/primitive/array/Real16.1.0.uavcan
+++ b/uavcan/primitive/array/Real16.1.0.uavcan
@@ -1,3 +1,3 @@
 float16[<=128] value                    # Exactly representable integers: [-2048, +2048]
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/primitive/array/Real32.1.0.uavcan
+++ b/uavcan/primitive/array/Real32.1.0.uavcan
@@ -1,4 +1,4 @@
 void1
 float32[<=64] value                     # Exactly representable integers: [-16777216, +16777216]
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/primitive/array/Real64.1.0.uavcan
+++ b/uavcan/primitive/array/Real64.1.0.uavcan
@@ -1,4 +1,4 @@
 void2
 float64[<=32] value                     # Exactly representable integers: [-2**53, +2**53]
-@assert offset % 8 == {0}
-@assert offset.max / 8 == 257
+@assert _offset_ % 8 == {0}
+@assert _offset_.max / 8 == 257

--- a/uavcan/register/384.Access.0.1.uavcan
+++ b/uavcan/register/384.Access.0.1.uavcan
@@ -76,14 +76,14 @@
 # Use the List service to obtain the list of registers on the node.
 Name.0.1 name
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}
 
 # Value to be written. Empty if no write is required.
 void4
 Value.0.1 value
 
-@assert offset.min % 8 == 0
-@assert offset.max % 8 == 0
+@assert _offset_.min % 8 == 0
+@assert _offset_.max % 8 == 0
 
 ---
 
@@ -121,5 +121,5 @@ void2
 # was written successfully, unless write was not requested.
 Value.0.1 value
 
-@assert offset.min % 8 == 0
-@assert offset.max % 8 == 0
+@assert _offset_.min % 8 == 0
+@assert _offset_.max % 8 == 0

--- a/uavcan/register/385.List.0.1.uavcan
+++ b/uavcan/register/385.List.0.1.uavcan
@@ -10,4 +10,4 @@ uint16 index
 # Empty name in response means that the index is out of bounds, i.e., discovery is finished.
 Name.0.1 name
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/register/Name.0.1.uavcan
+++ b/uavcan/register/Name.0.1.uavcan
@@ -5,4 +5,4 @@
 void2
 uint8[<=50] name
 
-@assert offset % 8 == {0}
+@assert _offset_ % 8 == {0}

--- a/uavcan/register/Value.0.1.uavcan
+++ b/uavcan/register/Value.0.1.uavcan
@@ -28,5 +28,5 @@ uavcan.primitive.array.Real16.1.0 real16        # Tag 14    Exactly representabl
 
 # Tag 15 is reserved
 
-@assert offset.min == 4                 # Empty and the tag
-@assert offset.max == 257 * 8 + 4       # 257 bytes per field max and the tag
+@assert _offset_.min == 4                 # Empty and the tag
+@assert _offset_.max == 257 * 8 + 4       # 257 bytes per field max and the tag

--- a/uavcan/si/acceleration/Scalar.1.0.uavcan
+++ b/uavcan/si/acceleration/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 meter_per_second_per_second
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/acceleration/Vector3.1.0.uavcan
+++ b/uavcan/si/acceleration/Vector3.1.0.uavcan
@@ -1,4 +1,4 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32[3] meter_per_second_per_second
-@assert offset / 8 == {15}
-@assert offset % 8 == {0}
+@assert _offset_ / 8 == {15}
+@assert _offset_ % 8 == {0}

--- a/uavcan/si/angle/Quaternion.1.0.uavcan
+++ b/uavcan/si/angle/Quaternion.1.0.uavcan
@@ -1,4 +1,4 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32[4] wxyz
-@assert offset / 8 == {19}              # Optimized for three CAN 2.0 frames
-@assert offset % 8 == {0}
+@assert _offset_ / 8 == {19}              # Optimized for three CAN 2.0 frames
+@assert _offset_ % 8 == {0}

--- a/uavcan/si/angle/Scalar.1.0.uavcan
+++ b/uavcan/si/angle/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 radian
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/angular_velocity/Scalar.1.0.uavcan
+++ b/uavcan/si/angular_velocity/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 radian_per_second
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/angular_velocity/Vector3.1.0.uavcan
+++ b/uavcan/si/angular_velocity/Vector3.1.0.uavcan
@@ -1,4 +1,4 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32[3] radian_per_second
-@assert offset / 8 == {15}
-@assert offset % 8 == {0}
+@assert _offset_ / 8 == {15}
+@assert _offset_ % 8 == {0}

--- a/uavcan/si/duration/Scalar.1.0.uavcan
+++ b/uavcan/si/duration/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 second
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/duration/WideScalar.1.0.uavcan
+++ b/uavcan/si/duration/WideScalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float64 second
-@assert offset / 8 == {11}              # Two CAN 2.0 frames
+@assert _offset_ / 8 == {11}              # Two CAN 2.0 frames

--- a/uavcan/si/electric_charge/Scalar.1.0.uavcan
+++ b/uavcan/si/electric_charge/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 coulomb
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/electric_current/Scalar.1.0.uavcan
+++ b/uavcan/si/electric_current/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 ampere
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/energy/Scalar.1.0.uavcan
+++ b/uavcan/si/energy/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 joule
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/length/Scalar.1.0.uavcan
+++ b/uavcan/si/length/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 meter
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/length/Vector3.1.0.uavcan
+++ b/uavcan/si/length/Vector3.1.0.uavcan
@@ -1,4 +1,4 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32[3] meter
-@assert offset / 8 == {15}
-@assert offset % 8 == {0}
+@assert _offset_ / 8 == {15}
+@assert _offset_ % 8 == {0}

--- a/uavcan/si/length/WideVector3.1.0.uavcan
+++ b/uavcan/si/length/WideVector3.1.0.uavcan
@@ -1,4 +1,4 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float64[3] meter
-@assert offset / 8 == {27}
-@assert offset % 8 == {0}
+@assert _offset_ / 8 == {27}
+@assert _offset_ % 8 == {0}

--- a/uavcan/si/magnetic_field_strength/Scalar.1.0.uavcan
+++ b/uavcan/si/magnetic_field_strength/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 tesla
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/magnetic_field_strength/Vector3.1.0.uavcan
+++ b/uavcan/si/magnetic_field_strength/Vector3.1.0.uavcan
@@ -1,4 +1,4 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32[3] tesla
-@assert offset / 8 == {15}
-@assert offset % 8 == {0}
+@assert _offset_ / 8 == {15}
+@assert _offset_ % 8 == {0}

--- a/uavcan/si/mass/Scalar.1.0.uavcan
+++ b/uavcan/si/mass/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 kilogram
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/power/Scalar.1.0.uavcan
+++ b/uavcan/si/power/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 watt
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/pressure/Scalar.1.0.uavcan
+++ b/uavcan/si/pressure/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 pascal
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/temperature/Scalar.1.0.uavcan
+++ b/uavcan/si/temperature/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 kelvin
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/velocity/Scalar.1.0.uavcan
+++ b/uavcan/si/velocity/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 meter_per_second
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/velocity/Vector3.1.0.uavcan
+++ b/uavcan/si/velocity/Vector3.1.0.uavcan
@@ -1,4 +1,4 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32[3] meter_per_second
-@assert offset / 8 == {15}
-@assert offset % 8 == {0}
+@assert _offset_ / 8 == {15}
+@assert _offset_ % 8 == {0}

--- a/uavcan/si/voltage/Scalar.1.0.uavcan
+++ b/uavcan/si/voltage/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 volt
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/volume/Scalar.1.0.uavcan
+++ b/uavcan/si/volume/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 cubic_meter
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/si/volumetric_flow_rate/Scalar.1.0.uavcan
+++ b/uavcan/si/volumetric_flow_rate/Scalar.1.0.uavcan
@@ -1,3 +1,3 @@
 uavcan.time.SynchronizedAmbiguousTimestamp.1.0 timestamp
 float32 cubic_meter_per_second
-@assert offset / 8 == {7}               # Single CAN 2.0 frame
+@assert _offset_ / 8 == {7}               # Single CAN 2.0 frame

--- a/uavcan/time/31744.Synchronization.1.0.uavcan
+++ b/uavcan/time/31744.Synchronization.1.0.uavcan
@@ -179,5 +179,5 @@ uint8 PUBLISHER_TIMEOUT_PERIOD_MULTIPLIER = 3
 # one second ago, this field must be zero.
 truncated uint56 previous_transmission_timestamp_microsecond
 
-@assert offset % 8 == {0}
-@assert offset.max <= 56    # Must fit into one CAN 2.0 frame (least capable transport, smallest MTU)
+@assert _offset_ % 8 == {0}
+@assert _offset_.max <= 56    # Must fit into one CAN 2.0 frame (least capable transport, smallest MTU)

--- a/uavcan/time/510.GetSynchronizationMasterInfo.0.1.uavcan
+++ b/uavcan/time/510.GetSynchronizationMasterInfo.0.1.uavcan
@@ -37,5 +37,5 @@ uint12 time_difference_tai_minus_utc
 # Reserved for future use
 void8
 
-@assert offset % 8 == {0}
-@assert offset.max <= 56   # It is nice to have the response fit into one transport frame, although not required.
+@assert _offset_ % 8 == {0}
+@assert _offset_.max <= 56   # It is nice to have the response fit into one transport frame, although not required.


### PR DESCRIPTION
This PR makes the standard set compatible with the ideas discussed here: [Alternative transport protocols](https://forum.uavcan.org/t/alternative-transport-protocols/324), and replaces all occurrences of `offset` with `_offset_`. The latter was previously discussed, but no conclusion was made; consider it finalized in this PR.

I am going to merge it immediately to fix the outstanding issues with the PyDSDL's CI -- the cowboy workflow I've been practicing in both repos seems to have exhausted its virtues, so from now on (seeing as Scott is beginning to rely on PyDSDL as well) I will be more careful in rolling out drastic changes.