### PR TITLE
expose public regulated data types as a python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'pycyphal>=1.20.0']
+requires = ['setuptools', 'pycyphal~=1.20.0']
 build-backend = 'setuptools.build_meta'
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ['setuptools', 'pycyphal>=1.20.0']
+build-backend = 'setuptools.build_meta'
+
+[project]
+name = 'public-regulated-data-types'
+version = '0.0.1'
+
+[tool.setuptools]
+packages = []
+exclude-package-data = { public_regulated_data_types = [
+	"*.dsdl",
+] } # don't include dsdl files in wheel

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+import pycyphal
+from contextlib import suppress
+from pathlib import Path
+from setuptools import Command, setup
+from setuptools.command.build import build
+import pathlib
+
+
+class CustomCommand(Command):
+    def initialize_options(self) -> None:
+        self.bdist_dir = None
+        self.proto_msgs_path = None
+        self.pkg_name = None
+
+    def finalize_options(self) -> None:
+        self.pkg_name = self.distribution.get_name().replace("-", "_")
+        self.proto_msgs_path = Path(self.pkg_name)
+        with suppress(Exception):
+            self.bdist_dir = Path(self.get_finalized_command("bdist_wheel").bdist_dir)
+
+    def run(self) -> None:
+        if self.bdist_dir:
+            # Create package structure
+            output_dir = self.bdist_dir
+            cur_path = pathlib.Path(__file__).parent
+            uavcan_path = cur_path / "uavcan"
+            pycyphal.dsdl.compile_all(
+                root_namespace_directories=[uavcan_path.resolve()],
+                output_directory=output_dir,
+            )
+
+
+class CustomBuild(build):
+    sub_commands = [("build_custom", None)] + build.sub_commands
+
+
+setup(cmdclass={"build": CustomBuild, "build_custom": CustomCommand})

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,10 @@ class CustomCommand(Command):
             cur_path = pathlib.Path(__file__).parent
             uavcan_path = cur_path / "uavcan"
             pycyphal.dsdl.compile_all(
-                root_namespace_directories=[uavcan_path.resolve()],
+                root_namespace_directories=[
+                    cur_path / "uavcan",
+                    cur_path / "reg",
+                ],
                 output_directory=output_dir,
             )
 


### PR DESCRIPTION
# Problem
I want to write a small tool that uses pycyphal and the public regulated data types. 
But is quite annoying that it is not possible to just add/install the public regulated data types as a dependency.

I understand that this is a deliberate decision to make it possible to add custom data types, but my tool does not rely on custom data types and I want to being able to have one setup with all dependencies without needing some custom setup from the end user.

# Solution
It is then possible to use this dependency by just specifying the git repository
```
pip install git+ssh://git@github.com/ot-goegelem/public_regulated_data_types.git@feature/python_package
```