### PR TITLE
file/directory crc

### DIFF
--- a/uavcan/file/410.Crc.0.1.dsdl
+++ b/uavcan/file/410.Crc.0.1.dsdl
@@ -1,0 +1,51 @@
+# Request to compute the CRC of a file or directory.
+#
+# The CRC is computed using the CRC-32 algorithm.
+# The CRC is computed over the contents of the file or directory, not over the metadata.
+#
+# Case File:
+#   - If the path points to a file, the CRC is computed over the contents of the file.
+
+# Case Directory:
+#   - If the path points to a directory, the CRC is computed over a concatenation of the filenames.
+#   - The filenames are concatenated with a newline character (\n).
+#   - The filenames only contain the base name of the file, not the full path.
+#   - The content of sub-directories are not included in the CRC computation.
+#
+#   - Example:
+#      - Filesystem
+#        dir
+#        ├── sub-dir
+#        │   ├── sub-file1.txt
+#        │   └── sub-file2.txt
+#        ├── file1.txt
+#        └── file2.txt
+#
+#	   - The CRC request on the directory 'dir' will compute the CRC over the following content:
+#        """
+#            sub-dir
+#            file1.txt
+#            file2.txt
+#		 """
+#        i.e.: "sub-dir\nfile1.txt\nfile2.txt"
+# 	   - via python
+#       ``` python
+#           import binascii
+# 		    string = "sub-dir\nfile1.txt\nfile2.txt"
+# 		    print(f"0x{binascii.crc32(bytes(string, encoding='ascii')):08x}")
+#       ```
+#      - The CRC value will be 0x58c8a463
+
+Path.2.0 path
+
+@extent 300 * 8
+
+---
+
+Error.1.0 error
+# Result of the operation.
+
+uint32 crc
+# CRC of the file or directory.
+
+@extent 48 * 8

--- a/uavcan/file/410.Crc.0.1.dsdl
+++ b/uavcan/file/410.Crc.0.1.dsdl
@@ -1,6 +1,6 @@
 # Request to compute the CRC of a file or directory.
 #
-# The CRC is computed using the CRC-32 algorithm.
+# The CRC is computed using the CRC-32C algorithm documented in the Cyphal specification.
 # The CRC is computed over the contents of the file or directory, not over the metadata.
 #
 # Case File:
@@ -30,11 +30,16 @@
 #        i.e.: "sub-dir\nfile1.txt\nfile2.txt"
 # 	   - via python
 #       ``` python
-#           import binascii
-# 		    string = "sub-dir\nfile1.txt\nfile2.txt"
-# 		    print(f"0x{binascii.crc32(bytes(string, encoding='ascii')):08x}")
+#           ls=[
+#               "sub-dir",
+#               "file1.txt",
+#               "file2.txt",
+#           ]
+#           crc = CRC32C()
+#           crc.add(bytes("\n".join(ls), encoding='ascii'))
+#           print(f"0x{crc.value:08x}")
 #       ```
-#      - The CRC value will be 0x58c8a463
+#      - The CRC-32C value will be 0xecd3cb62
 
 Path.2.0 path
 
@@ -46,6 +51,6 @@ Error.1.0 error
 # Result of the operation.
 
 uint32 crc
-# CRC of the file or directory.
+# CRC of the file or directory in little-endian byte order.
 
 @extent 48 * 8


### PR DESCRIPTION
In order to check the integrity of file transfers or directory listings it would be nice to have a way of requesting a checksum over a file/directory in order to detect edge cases where the file/directory changes between subsequent requests.

Additionally it would also allow to do some prior checks in order to not sync any files that are already present.
 
 To be fair the cyphal specification mentions the methodology to put "hash-files" near the real files (like `image.bin.sha256`) which works for "static" files, but this becomes cumbersome for files that change all the time, because someone has to update those "hash-files". 
 Unfortunately this will also not help in the "list-directory" case as it is very hard to detect an "a file prior to the current index was deleted" error where the file that would have been at the current index prior to deletion will not show up in the listing. 